### PR TITLE
Stop noise from appearing on generated images

### DIFF
--- a/01_Diffusion_Models_Tutorial/Diffusion Model.ipynb
+++ b/01_Diffusion_Models_Tutorial/Diffusion Model.ipynb
@@ -907,6 +907,7 @@
     "        t = torch.full((1,), i, dtype=torch.long, device=device)\n",
     "        labels = torch.tensor([c] * NUM_DISPLAY_IMAGES).resize(NUM_DISPLAY_IMAGES, 1).float().to(device)\n",
     "        imgs = diffusion_model.backward(x=imgs, t=t, model=unet.eval().to(device), labels = labels)\n",
+    "    imgs = imgs.clamp(-1, 1)\n",
     "    for idx, img in enumerate(imgs):\n",
     "        ax[c][idx].imshow(reverse_transform(img))\n",
     "        ax[c][idx].set_title(f\"Class: {classes[c]}\", fontsize = 100)\n",


### PR DESCRIPTION
I clamped the images so there is no noise in the image. For example, this is what an image would look like without clamping:
![image](https://github.com/dtransposed/code_videos/assets/127988888/17df9f52-99c9-49c4-8e7d-1db1bd03073c)
The blue dots aren't supposed to be there, so you can clamp to get rid of them.
Hope this helps! :)